### PR TITLE
Restore function extensions on the build agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 obj
 csx
 .vs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin
 obj
 csx
 .vs

--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ curl -s -XPOST "http://localhost:7071/api/orchestrators/GetIndexNamesOrchestrato
 curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator/1" -d @samples/body-reindex.json | tee response.json
 
 ```
-The function takes about 10 mins to run so the above call return with a 202 after starting the function. If an instance
-with ID '123456789' is already running then a 409 error will be returned.
+The function takes about 10 mins to run so the above call return with a 202
+after starting the function. If an instance with ID '123456789' is already
+running then a 409 error will be returned.
 ```
 #the following command will get the status of the function
 curl $(jq -r '.statusQueryGetUri' response.json)
 ```
-The above command uses `jq` to query using the Status Check URL. Run it periodically to return the function status (typically it will be "inProgress" or "Completed").
+The above command uses `jq` to query using the Status Check URL. Run it
+periodically to return the function status (typically it will be "inProgress"
+or "Completed").
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ curl -s -XPOST "http://localhost:7071/api/orchestrators/OrchestratorFunction/123
 curl -s -XPOST "http://localhost:7071/api/orchestrators/OrchestratorFunction/123456789" -d @samples/body-with-index-definition.json | tee response.json
 
 #Run the suborchestration to get the idle/active index names
-curl -s -XPOST "http://localhost:7071/api/orchestrators/GetIndexNamesOrchestrator/1" -d 'service-search-organisations-2' | tee ../response.json
+curl -s -XPOST "http://localhost:7071/api/orchestrators/GetIndexNamesOrchestrator/1" -d 'service-search-organisations-2' | tee response.json
 
 #Run the suborchestration to reindex the idle index and make it active
-curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator/1" -d @samples/body-reindex.json | tee ../response.json
+curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator/1" -d @samples/body-reindex.json | tee response.json
 
 ```
 The function takes about 10 mins to run so the above call return with a 202 after starting the function. If an instance

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,12 @@ pool:
   vmImage: 'ubuntu-16.04'
 
 steps:
+  - bash: sudo apt-get install azure-functions-core-tools
+    displayName: 'sudo apt-get install azure-functions-core-tools'
+
+  - bash: func extensions install
+    displayName: 'func extensions install'
+
   - script: npm install
     displayName: 'npm install'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 pool:
   vmImage: 'ubuntu-16.04'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,7 +358,7 @@
         "@types/lodash": "^4.14.119",
         "@types/validator": "^9.4.3",
         "axios": "~0.18.0",
-        "azure-functions-typescript": "github:christopheranderson/azure-functions-typescript#bbb6b0fd67fcdf82cabaf1af41e65fa6d8496ff5",
+        "azure-functions-typescript": "github:christopheranderson/azure-functions-typescript",
         "commander": "~2.9.0",
         "debug": "~2.6.9",
         "lodash": "^4.17.11",


### PR DESCRIPTION
The progression of this change was to add `bin/` to the repo which fixed the initial problem of the function extensions not being available within the function app in Azure. That worked and so I've progressed the change to not having to store generated files within the repo and instead restore them as part of the build.
I've squashed the intermediate commits as although it showed the progression I don't see the value of them within the history of _this_ repo.

The end result is that the function app now works when deployed to Azure!