### PR TITLE
Change method of preventing multiple re-index requests

### DIFF
--- a/HttpStart/function.json
+++ b/HttpStart/function.json
@@ -5,7 +5,7 @@
       "name": "req",
       "type": "httpTrigger",
       "direction": "in",
-      "route": "orchestrators/{functionName}/{instanceId}",
+      "route": "orchestrators/{functionName}",
       "methods": ["post"]
     },
     {

--- a/HttpStart/index.js
+++ b/HttpStart/index.js
@@ -1,29 +1,10 @@
 const df = require('durable-functions');
 
 module.exports = async function httpStart(context, req) {
-  const client = df.getClient(context);
-  const instanceId = req.params.instanceId;
   const functionName = req.params.functionName;
+  const client = df.getClient(context);
 
-  // Can not use getStatus as it throws an exception if instanceId does not exist.
-  // This is a bug in azure-durable-functions:
-  //   https://github.com/Azure/azure-functions-durable-js/issues/40
-  const instances = await client.getStatusAll();
-
-  const runningInstanceExists = instances.some(
-    i => i.instanceId === instanceId && i.runtimeStatus === 'Running'
-  );
-
-  // console.log(instances.map( (i)=> { return i.instanceId }));
-  // console.log([instanceId, isInstanceRunning]);
-
-  if (runningInstanceExists) {
-    return {
-      body: `An instance with ID '${instanceId}' is already running.`,
-      status: 409,
-    };
-  }
+  const instanceId = await client.startNew(functionName, undefined, req.body);
   context.log(`Starting orchestration with ID = '${instanceId}'.`);
-  await client.startNew(functionName, instanceId, req.body);
   return client.createCheckStatusResponse(req, instanceId);
 };

--- a/OrchestratorFunction/index.js
+++ b/OrchestratorFunction/index.js
@@ -8,22 +8,14 @@ module.exports = df.orchestrator(function* orchestratorFunctionGenerator(context
 
   context.log('Starting Orchestration using Chaining and Monitor patterns');
 
-  const indexNames = yield context.df.callSubOrchestrator(
-    'GetIndexNamesOrchestrator',
-    apimApiName,
-    `${context.df.instanceId}:0`
-  );
+  const indexNames = yield context.df.callSubOrchestrator('GetIndexNamesOrchestrator', apimApiName);
   context.log({ indexNames });
 
   const parameters = {
     apimApiName,
     indexNames,
   };
-  const returnStatus = yield context.df.callSubOrchestrator(
-    'ReIndexOrchestrator',
-    { parameters },
-    `${context.df.instanceId}:0`
-  );
+  const returnStatus = yield context.df.callSubOrchestrator('ReIndexOrchestrator', { parameters });
   context.log({ returnStatus });
 
   return returnStatus;

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ No authorization is required when the function is running locally.
 ### MacOS/Linux
 ```
 #The whole orchestration (idle index definition copied from the active index)
-curl -s -XPOST "http://localhost:7071/api/orchestrators/OrchestratorFunction/123456789" -d @samples/body.json | tee response.json
+curl -s -XPOST "http://localhost:7071/api/orchestrators/OrchestratorFunction" -d @samples/body.json | tee response.json
 
 #Run the suborchestration to get the idle/active index names
-curl -s -XPOST "http://localhost:7071/api/orchestrators/GetIndexNamesOrchestrator/1" -d 'service-search-organisations-2' | tee response.json
+curl -s -XPOST "http://localhost:7071/api/orchestrators/GetIndexNamesOrchestrator" -d 'service-search-organisations-2' | tee response.json
 
 #Run the suborchestration to reindex the idle index and make it active
-curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator/1" -d @samples/body-reindex.json | tee response.json
+curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator" -d @samples/body-reindex.json | tee response.json
 
 ```
 The full orchestration takes ~10 mins to complete. The initial request to the

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ curl -s -XPOST "http://localhost:7071/api/orchestrators/ReIndexOrchestrator" -d 
 ```
 The full orchestration takes ~10 mins to complete. The initial request to the
 function returns a 202 response, if successful.
-If an instance with ID '123456789' is already running a 409 response will be
-returned.
 The 202 response contains a `statusQueryGetUri` (also available in the
 `location` header). This URI can be used to monitor the status of the function.
 If one of the commands above has been run and

--- a/ReIndexOrchestrator/index.js
+++ b/ReIndexOrchestrator/index.js
@@ -14,6 +14,10 @@ module.exports = df.orchestrator(function* orchestratorFunctionGenerator(context
   // as for the index we can do this
   const indexerName = indexNames.idle;
 
+  if (yield context.df.callActivity('GetIndexerStatus', indexerName) === 'inProgress') {
+    return 'failed: indexer currently running';
+  }
+
   const indexDefinition = yield context.df.callActivity('GetIndexDefinition', indexNames.active);
   context.log({ indexDefinition });
 

--- a/samples/body.json
+++ b/samples/body.json
@@ -1,5 +1,5 @@
 {
   "parameters": { 
-    "apimApiName": "service-search-organisations-2"
+    "apimApiName": "service-search-organisations"
   }
 }


### PR DESCRIPTION
The app currently uses the singleton function pattern which has been removed and replaced with a guard within the code to check if an indexer is currently re-indexing.