### PR TITLE
:factory: Set specific task hub name

### DIFF
--- a/example.local.settings.json
+++ b/example.local.settings.json
@@ -11,6 +11,7 @@
     "apim-subscription": "",
     "search-api-admin-key": "",
     "search-api-version": "",
-    "search-hostname": ""
+    "search-hostname": "",
+    "task-hub-name": "localdevtaskhub"
   }
 }

--- a/host.json
+++ b/host.json
@@ -1,5 +1,10 @@
 {
   "version": "2.0",
+  "extensions": {
+    "durableTask": {
+      "hubName": "%task-hub-name%"
+    }
+  },
   "logging": {
     "logLevel": {
       "default": "Information"

--- a/scripts/generate-pr-app-name.sh
+++ b/scripts/generate-pr-app-name.sh
@@ -9,6 +9,9 @@ echo "PR_NUMBER: '$PR_NUMBER'."
 APP_NAME=nhsuk-apim-blue-green-deploy-func-dev-ne-PR-${PR_NUMBER}
 echo "APP_NAME: '$APP_NAME'."
 
+TASK_HUB_NAME="${TASK_HUB_NAME}${PR_NUMBER}"
+echo "TASK_HUB_NAME: '$TASK_HUB_NAME'."
 # Set APP_NAME for use in down stream tasks
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables?view=azdevops&tabs=shell#set-in-script
 echo "##vso[task.setvariable variable=APP_NAME]$APP_NAME"
+echo "##vso[task.setvariable variable=TASK_HUB_NAME]$TASK_HUB_NAME"


### PR DESCRIPTION
This will prevent functions that are using the same storage account from
conflicting and stealing messages from one another.  See the note near
the end of the page
https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-task-hubs