### PR TITLE
Move searchApiAdminKey out of options

### DIFF
--- a/GetIndexDefinition/index.js
+++ b/GetIndexDefinition/index.js
@@ -4,7 +4,7 @@ module.exports = async function index(context) {
   const indexName = context.bindings.parameters.indexName;
   const searchApiVersion = context.bindings.parameters.searchApiVersion;
   try {
-    const response = await azureSearchRequest(`indexes/${indexName}`, { searchApiVersion });
+    const response = await azureSearchRequest(`indexes/${indexName}`, searchApiVersion);
     const indexDefinition = response.body;
     // We delete the index name to allow us to 'put' the index definition to any named index
     delete indexDefinition.name;

--- a/GetIndexerLastRunStatus/index.js
+++ b/GetIndexerLastRunStatus/index.js
@@ -4,7 +4,7 @@ module.exports = async function getIndexerLastRunStatus(context) {
   const indexerName = context.bindings.parameters.indexerName;
   const searchApiVersion = context.bindings.parameters.searchApiVersion;
   try {
-    const response = await azureSearchRequest(`indexers/${indexerName}/status`, { searchApiVersion });
+    const response = await azureSearchRequest(`indexers/${indexerName}/status`, searchApiVersion);
     return response.body.lastResult.status;
   } catch (e) {
     throw Error(`Could not get last run status for indexer '${indexerName}' (${e.message})`);

--- a/GetIndexerStatus/index.js
+++ b/GetIndexerStatus/index.js
@@ -4,7 +4,7 @@ module.exports = async function getIndexerStatus(context) {
   const indexerName = context.bindings.parameters.indexerName;
   const searchApiVersion = context.bindings.parameters.searchApiVersion;
   try {
-    const response = await azureSearchRequest(`indexers/${indexerName}/status`, { searchApiVersion });
+    const response = await azureSearchRequest(`indexers/${indexerName}/status`, searchApiVersion);
     return response.body.status;
   } catch (e) {
     throw Error(`Could not get status for indexer '${indexerName}' (${e.message})`);

--- a/ReIndex/index.js
+++ b/ReIndex/index.js
@@ -6,14 +6,12 @@ module.exports = async function reindex(context) {
   const searchApiVersion = context.bindings.parameters.searchApiVersion;
   const indexDefinition = context.bindings.parameters.indexDefinition;
   try {
-    await azureSearchRequest(`indexes/${indexName}`, {
+    await azureSearchRequest(`indexes/${indexName}`, searchApiVersion, {
       body: JSON.stringify(indexDefinition),
       method: 'put',
-      searchApiVersion,
     });
-    await azureSearchRequest(`indexers/${indexerName}/run`, {
+    await azureSearchRequest(`indexers/${indexerName}/run`, searchApiVersion, {
       method: 'post',
-      searchApiVersion,
     });
   } catch (e) {
     throw Error(`Could not run indexer '${indexerName}' (${e.message})`);

--- a/lib/AzureSearchRequest.js
+++ b/lib/AzureSearchRequest.js
@@ -1,10 +1,12 @@
 const rp = require('request-promise-native');
 const azureSearchUrl = require('./AzureSearchUrl');
 
-module.exports = async function azureSearchRequest(searchUrl, options = {}) {
+module.exports = async function azureSearchRequest(searchUrl, searchApiVersion, options = {}) {
+  if (!searchApiVersion) {
+    throw Error('searchApiVersion parameter is missing');
+  }
   const method = options.method || 'get';
   const body = options.body || '{}';
-  const searchApiVersion = options.searchApiVersion;
 
   const searchApiAdminKey = process.env['search-api-admin-key'];
 

--- a/test/unit/lib/AzureSearchRequest.js
+++ b/test/unit/lib/AzureSearchRequest.js
@@ -25,15 +25,20 @@ describe('AzureSearchRequest', () => {
         'api-key': 'key',
       },
     };
+    const requestBody = { prop1: 'value1' };
+    const responseBody = { response: 'ok' };
     nock('https://hostname/', expectedHeaders)
       .get(/path/, {})
       .times(1)
       .query({ 'api-version': searchApiVersion })
-      .reply(200);
-
-    const response = await azureSearchRequest('path', { searchApiVersion });
+      .reply(200, responseBody);
+    const response = await azureSearchRequest('path', searchApiVersion, {
+      method: 'get',
+      requestBody,
+    });
     expect(response).to.not.be.null;
     expect(response.statusCode).to.equal(200);
+    expect(response.body).to.deep.equal(responseBody);
   });
   it('should make correctly set up HTTP request with defaults', async () => {
     const searchApiVersion = '2017-11-11';
@@ -49,8 +54,25 @@ describe('AzureSearchRequest', () => {
       .query({ 'api-version': searchApiVersion })
       .reply(200);
 
-    const response = await azureSearchRequest('https://hostname/path', { searchApiVersion });
+    const response = await azureSearchRequest('https://hostname/path', searchApiVersion);
     expect(response).to.not.be.null;
     expect(response.statusCode).to.equal(200);
+  });
+  it('should throw an exception if searchApiversion parameter is missing', async () => {
+    const searchApiVersion = '2017-11-11';
+    const expectedHeaders = {
+      reqheaders: {
+        'Content-Type': 'application/json',
+        'api-key': 'key',
+      },
+    };
+    nock('https://hostname/', expectedHeaders)
+      .get(/path/, {})
+      .times(1)
+      .query({ 'api-version': searchApiVersion })
+      .reply(200);
+
+    await expect(azureSearchRequest('https://hostname/path'))
+      .to.be.rejectedWith(Error, 'searchApiVersion parameter is missing');
   });
 });


### PR DESCRIPTION
While investigating why test coverage was not 100% for AzureSearchRequest I noticed that the searchApiVersion parameter should not be considered an option.

Introduced a specific parameter for it and added a check for it being populated as well as a test. 

Coverage for the method is now 100%.