### PR TITLE
Update supported Azure Search API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+1.1.0 / 2019-09-24
+=================
+- Add General Availability Azure Search version which supports complex types to list of valid parameters 
+
+1.0.0
+========
+- Initial release

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ and are easy to use. Either through a
 
 The body of the request should contain the following parameters:
 
-| name | mandatory | description | default |
-|------|-----------|-------------|---------| 
-| apimApiName | yes | The name of the API in Azure API Manager | n/a |
-| searchApiVersion | no | The version identifier for the Azure Search API | 2017-11-11 |
+| Name | Description | Default | Allowable Values | Required |
+|------|-----------|-------------|---------| ---------------- |
+| apimApiName | The name of the API in Azure API Manager | | | yes |
+| searchApiVersion | The version identifier for the Azure Search API| 2017-11-11 | 2019-05-06 | no |
 
 ### Curl example
 

--- a/lib/ValidateSearchApiVersion.js
+++ b/lib/ValidateSearchApiVersion.js
@@ -1,5 +1,5 @@
 const supportedVersions = {
-  alternatives: ['2017-11-11-Preview'],
+  alternatives: ['2019-05-06', '2017-11-11-Preview'],
   default: '2017-11-11',
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "index-switch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A function app to switch between an active and idle index to allow for zero azure search downtime with reindexing",
   "main": "index.js",
   "directories": {

--- a/test/unit/lib/ValidateSearchApiVersion.js
+++ b/test/unit/lib/ValidateSearchApiVersion.js
@@ -6,7 +6,9 @@ const expect = chai.expect;
 describe('SearchApiVersionUtils', () => {
   describe('ValidateSearchApiVersion', () => {
     it('should handle valid versions', () => {
+      expect(validateSearchApiVersion('2019-05-06')).to.equal('2019-05-06');
       expect(validateSearchApiVersion('2017-11-11')).to.equal('2017-11-11');
+      expect(validateSearchApiVersion('2017-11-11-Preview')).to.equal('2017-11-11-Preview');
     });
     it('should handle default versions', () => {
       expect(validateSearchApiVersion()).to.equal('2017-11-11');


### PR DESCRIPTION
Remove the preview version of the api not that the features in it are
in the latest General Availability version. The features in this
version (complex types) are used in Find a Pharmacy