### PR TITLE
Rebuild index from scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.0 / 2020-02-04
+==================
+- On reindexing rebuild index from scratch to pickup deletes
+
 1.2.0 / 2019-09-25
 ==================
 - Update npm dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.2.0 / 2020-02-04
+1.3.0 / 2020-02-06
 ==================
 - On reindexing rebuild index from scratch to pickup deletes
 

--- a/ReIndex/index.js
+++ b/ReIndex/index.js
@@ -13,6 +13,9 @@ module.exports = async function reindex(context) {
       body: JSON.stringify(indexDefinition),
       method: 'put',
     });
+    await azureSearchRequest(`indexers/${indexerName}/reset`, searchApiVersion, {
+      method: 'post',
+    });
     await azureSearchRequest(`indexers/${indexerName}/run`, searchApiVersion, {
       method: 'post',
     });

--- a/ReIndex/index.js
+++ b/ReIndex/index.js
@@ -7,6 +7,9 @@ module.exports = async function reindex(context) {
   const indexDefinition = context.bindings.parameters.indexDefinition;
   try {
     await azureSearchRequest(`indexes/${indexName}`, searchApiVersion, {
+      method: 'delete',
+    });
+    await azureSearchRequest(`indexes/${indexName}`, searchApiVersion, {
       body: JSON.stringify(indexDefinition),
       method: 'put',
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "index-switch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A function app to switch between an active and idle index to allow for zero azure search downtime with reindexing",
   "main": "index.js",
   "directories": {

--- a/test/unit/ReIndex.js
+++ b/test/unit/ReIndex.js
@@ -34,6 +34,11 @@ describe('ReIndex', () => {
   describe('ReIndex', async () => {
     it('should run a reindex', async () => {
       nock('https://hostname/')
+        .delete(new RegExp(`indexes/${indexName}`))
+        .times(1)
+        .query({ 'api-version': searchApiVersion })
+        .reply(200);
+      nock('https://hostname/')
         .put(new RegExp(`indexes/${indexName}`), indexDefinition)
         .times(1)
         .query({ 'api-version': searchApiVersion })
@@ -50,7 +55,7 @@ describe('ReIndex', () => {
   describe('error handling', async () => {
     it('should handle HTTP error statuses', async () => {
       nock('https://hostname/')
-        .put(/indexes/)
+        .delete(/indexes/)
         .times(1)
         .query({ 'api-version': searchApiVersion })
         .reply(500, 'Internal server error');

--- a/test/unit/ReIndex.js
+++ b/test/unit/ReIndex.js
@@ -43,6 +43,11 @@ describe('ReIndex', () => {
         .times(1)
         .query({ 'api-version': searchApiVersion })
         .reply(200);
+        nock('https://hostname/')
+          .post(new RegExp(`indexers/${indexerName}/reset`))
+          .times(1)
+          .query({ 'api-version': searchApiVersion })
+          .reply(200);
       nock('https://hostname/')
         .post(new RegExp(`indexers/${indexerName}/run`))
         .times(1)

--- a/test/unit/ReIndex.js
+++ b/test/unit/ReIndex.js
@@ -43,11 +43,11 @@ describe('ReIndex', () => {
         .times(1)
         .query({ 'api-version': searchApiVersion })
         .reply(200);
-        nock('https://hostname/')
-          .post(new RegExp(`indexers/${indexerName}/reset`))
-          .times(1)
-          .query({ 'api-version': searchApiVersion })
-          .reply(200);
+      nock('https://hostname/')
+        .post(new RegExp(`indexers/${indexerName}/reset`))
+        .times(1)
+        .query({ 'api-version': searchApiVersion })
+        .reply(200);
       nock('https://hostname/')
         .post(new RegExp(`indexers/${indexerName}/run`))
         .times(1)


### PR DESCRIPTION
As a part [FHS-399](https://jira.service.nhs.uk/browse/FHS-399), I've been investigating an issue where the indexes return records which are hidden in their results. Turns out this was down to the indexes not picking up the deletions from the data source. Explored fixing this by configuring a [SQL integrated change tracking policy](https://docs.microsoft.com/en-us/azure/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers#sql-integrated-change-tracking-policy), but this required modifying the pipelines to perform a merge to the data source which proved to be a lot more work than simply dropping and recreating the index to forcibly clear the data.